### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/edockter/jills-group-library.png?label=ready&title=Ready)](https://waffle.io/edockter/jills-group-library)
 # Library Manager
 [![Build Status](https://travis-ci.org/edockter/jills-group-library.svg?branch=master)](https://travis-ci.org/edockter/jills-group-library)
 ###A simple library manager.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/edockter/jills-group-library

This was requested by a real person (user edockter) on waffle.io, we're not trying to spam you.